### PR TITLE
traefik: remove play-when-prod from intranet gateway

### DIFF
--- a/infrastructure/infrastructure/templates/traefik.yaml
+++ b/infrastructure/infrastructure/templates/traefik.yaml
@@ -76,15 +76,6 @@ spec:
                 play-when-stage-www:
                   hostname: "www.stage.playwhen.{{ .Values.domain.intranet }}"
                   namespace: play-when-stage
-                play-when-prod-dex:
-                  hostname: "dex.playwhen.{{ .Values.domain.intranet }}"
-                  namespace: play-when-prod
-                play-when-prod-tinyauth:
-                  hostname: "tinyauth.playwhen.{{ .Values.domain.intranet }}"
-                  namespace: play-when-prod
-                play-when-prod-www:
-                  hostname: "www.playwhen.{{ .Values.domain.intranet }}"
-                  namespace: play-when-prod
                 prometheus:
                   hostname: "prometheus.{{ .Values.domain.intranet }}"
                   namespace: kube-prometheus-stack


### PR DESCRIPTION
The application has been verified using the external gateway, so it no longer needs these host names on the intranet gateway.